### PR TITLE
Match Pod headers case-insensitively.

### DIFF
--- a/lib/Dist/Zilla/Plugin/Readme/Brief.pm
+++ b/lib/Dist/Zilla/Plugin/Readme/Brief.pm
@@ -221,7 +221,7 @@ sub _description {
 
   for my $node_number ( 0 .. $#nodes ) {
     next unless Pod::Elemental::Selectors::s_command( head1 => $nodes[$node_number] );
-    next unless 'DESCRIPTION' eq $nodes[$node_number]->content;
+    next unless 'DESCRIPTION' eq uc $nodes[$node_number]->content;
     push @found, $nodes[$node_number];
   }
   if ( not @found ) {
@@ -250,7 +250,7 @@ sub _copyright_from_pod {
 
   for my $node_number ( 0 .. $#nodes ) {
     next unless Pod::Elemental::Selectors::s_command( head1 => $nodes[$node_number] );
-    next unless $nodes[$node_number]->content =~ /COPYRIGHT|LICENSE/msx;
+    next unless $nodes[$node_number]->content =~ /COPYRIGHT|LICENSE/imsx;
     push @found, $nodes[$node_number];
   }
   if ( not @found ) {

--- a/t/podnameci.t
+++ b/t/podnameci.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Basic Test using podname
+
+use Dist::Zilla::Util::Test::KENTNL 1.004 qw( dztest );
+use Test::DZil qw( simple_ini );
+
+my $test = dztest();
+$test->add_file( 'lib/Example.pm' => <<'EOF' );
+
+# PODNAME: Foo
+=head1 Description
+
+This is a description
+
+=cut
+
+1;
+
+EOF
+
+$test->add_file( 'dist.ini' => simple_ini( [ 'GatherDir' => {} ], [ 'Readme::Brief' => {} ], ) );
+$test->build_ok;
+
+my $src_file = $test->test_has_built_file('README');
+my @lines = $src_file->lines_utf8( { chomp => 1 } );
+
+use List::Util qw( first );
+
+ok( ( first { $_ eq 'Foo' } @lines ), 'Document name found and injected' );
+ok( ( first { $_ eq 'This is a description' } @lines ), 'Description injected' );
+ok( ( first { $_ eq 'INSTALLATION' } @lines ), 'Installation section injected' );
+ok( ( first { $_ eq 'COPYRIGHT AND LICENSE' } @lines ), 'Copyright section injected' );
+
+done_testing;
+


### PR DESCRIPTION
Pod headers should be allowed to be proper-case, so that proper casing can be determined by Pod authors. They should not be required to be uppercase, though Pod formatters might make them uppercase (e.g., when formatting man pages). So update the search for description and copyright headers to search case-insensitively.
