### PR TITLE
Add description_label attribute to use a H1 other than DESCRIPTION

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,7 @@ Release history for Dist-Zilla-Plugin-Readme-Brief
  [Features]
  - Can now specify `source_file` which forces the name of a file to use instead of `main_module` ( aristotle++ #5 )
  - Can now automatically use the `.pod` file alternative for your `main_module` if you ship one. ( aristotle++ #5 )
+ - Can override which section to take brief from instead of DESCRIPTION by setting `description_label` ( #4 )
 
 0.002005 2015-03-04T15:21:15Z 03b80f3
  [Dependencies::Stats]

--- a/README.mkdn
+++ b/README.mkdn
@@ -54,6 +54,8 @@ Determines the file that will be parsed for POD to populate the README from.
 By default, it uses your `main_module`, except if you have a `.pod` file with
 the same basename and path as your `main_module`, in which case it uses that.
 
+This parameter and associated `.pod` support is new in `v0.003000`
+
 ## installer
 
 Determines what installers to document in the `INSTALLATION` section.
@@ -74,11 +76,15 @@ this attribute allows you to control which, or all, and the order.
 
 The verbiage however has not yet been cleaned up such that having both is completely lucid.
 
+This parameter was introduced in version `v0.002000`
+
 ## description\_label
 
 This case-insensitive attribute defines what `=head1` node will be used for the description section of the brief.
 
 By default, this is `DESCRIPTION`.
+
+This parameter was introduced in version `v0.003000`
 
 # SEE ALSO
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -13,6 +13,8 @@ version 0.003000
     installer = eumm
     ; Override autodetected main_module or main_module.pod as a source
     source_file = lib/Path/To/Module.pm
+    ; Override name to use for brief body
+    description_label = WHAT IS THIS
 
 # DESCRIPTION
 
@@ -34,7 +36,7 @@ However, bugs are highly likely to be encountered, especially as there are no te
 # MECHANICS
 
 - Heading is derived from the `package` statement in the `source_file`
-- Description is extracted as the entire `H1Nest` of the section titled `DESCRIPTION` in the `source_file`
+- Description is extracted as the entire `H1Nest` of the section titled `DESCRIPTION` ( or whatever `description_label` is ) in the `source_file`
 - Installation instructions are automatically determined by the presence of either
     - A `Makefile.PL` file in your dist ( Where it assumes `EUMM` style )
     - A `Build.PL` file in your dist ( where it assumes `Module::Build` style )
@@ -71,6 +73,12 @@ this attribute allows you to control which, or all, and the order.
     installer = eumm   ; EUMM shown second, MB shown first
 
 The verbiage however has not yet been cleaned up such that having both is completely lucid.
+
+## description\_label
+
+This case-insensitive attribute defines what `=head1` node will be used for the description section of the brief.
+
+By default, this is `DESCRIPTION`.
 
 # SEE ALSO
 

--- a/lib/Dist/Zilla/Plugin/Readme/Brief.pm
+++ b/lib/Dist/Zilla/Plugin/Readme/Brief.pm
@@ -97,6 +97,21 @@ has 'installer' => (
 
 no Moose::Util::TypeConstraints;
 
+=attr description_label
+
+This case-insensitive attribute defines what C<=head1> node will be used for the description section of the brief.
+
+By default, this is C<DESCRIPTION>.
+
+=cut
+
+has 'description_label' => (
+  isa     => Str,
+  is      => 'ro',
+  lazy    => 1,
+  default => sub { 'DESCRIPTION' },
+);
+
 around 'mvp_multivalue_args' => sub {
   my ( $orig, $self, @rest ) = @_;
   return ( $self->$orig(@rest), 'installer' );
@@ -107,7 +122,11 @@ around 'mvp_aliases' => sub {
   return { %{ $self->$orig(@rest) }, installers => 'installer' };
 };
 
-around dump_config => config_dumper( __PACKAGE__, { attrs => [ 'installer', 'source_file', '_source_file_override' ] } );
+around dump_config => config_dumper( __PACKAGE__,
+  {
+    attrs => [ 'installer', 'source_file', '_source_file_override', 'description_label', ],
+  },
+);
 
 __PACKAGE__->meta->make_immutable;
 no Moose;
@@ -254,11 +273,11 @@ sub _description {
 
   for my $node_number ( 0 .. $#nodes ) {
     next unless Pod::Elemental::Selectors::s_command( head1 => $nodes[$node_number] );
-    next unless 'DESCRIPTION' eq uc $nodes[$node_number]->content;
+    next unless uc $self->description_label eq uc $nodes[$node_number]->content;
     push @found, $nodes[$node_number];
   }
   if ( not @found ) {
-    $self->log( 'DESCRIPTION not found in ' . $self->source_file->name );
+    $self->log( $self->description_label . ' not found in ' . $self->source_file->name );
     return q[];
   }
   return $self->_podtext_nodes( map { @{ $_->children } } @found );
@@ -333,6 +352,8 @@ EOFMB
   installer = eumm
   ; Override autodetected main_module or main_module.pod as a source
   source_file = lib/Path/To/Module.pm
+  ; Override name to use for brief body
+  description_label = WHAT IS THIS
 
 =head1 NOTE
 
@@ -347,7 +368,7 @@ However, bugs are highly likely to be encountered, especially as there are no te
 
 =item * Heading is derived from the C<package> statement in the C<source_file>
 
-=item * Description is extracted as the entire C<H1Nest> of the section titled C<DESCRIPTION> in the C<source_file>
+=item * Description is extracted as the entire C<H1Nest> of the section titled C<DESCRIPTION> ( or whatever C<description_label> is ) in the C<source_file>
 
 =item * Installation instructions are automatically determined by the presence of either
 

--- a/lib/Dist/Zilla/Plugin/Readme/Brief.pm
+++ b/lib/Dist/Zilla/Plugin/Readme/Brief.pm
@@ -32,6 +32,8 @@ Determines the file that will be parsed for POD to populate the README from.
 By default, it uses your C<main_module>, except if you have a C<.pod> file with
 the same basename and path as your C<main_module>, in which case it uses that.
 
+This parameter and associated C<.pod> support is new in C<v0.003000>
+
 =cut
 
 has _source_file_override => (
@@ -83,6 +85,8 @@ this attribute allows you to control which, or all, and the order.
 
 The verbiage however has not yet been cleaned up such that having both is completely lucid.
 
+This parameter was introduced in version C<v0.002000>
+
 =cut
 
 has 'installer' => (
@@ -102,6 +106,8 @@ no Moose::Util::TypeConstraints;
 This case-insensitive attribute defines what C<=head1> node will be used for the description section of the brief.
 
 By default, this is C<DESCRIPTION>.
+
+This parameter was introduced in version C<v0.003000>
 
 =cut
 

--- a/t/description_label.t
+++ b/t/description_label.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Basic Test
+
+use Dist::Zilla::Util::Test::KENTNL 1.004 qw( dztest );
+use Test::DZil qw( simple_ini );
+
+my $test = dztest();
+$test->add_file( 'lib/Example.pm' => <<'EOF' );
+
+package Foo;
+
+=head1 WHAT IS THIS
+
+This is a description
+
+=cut
+
+1;
+
+EOF
+
+$test->add_file(
+  'dist.ini' => simple_ini(
+    [ 'GatherDir' => {} ],                                            #
+    [ 'Readme::Brief' => { description_label => "WHAT IS THIS" } ],
+  )
+);
+$test->build_ok;
+
+my $src_file = $test->test_has_built_file('README');
+my @lines = $src_file->lines_utf8( { chomp => 1 } );
+
+use List::Util qw( first );
+
+ok( ( first { $_ eq 'Foo' } @lines ),                   'Document name found and injected' );
+ok( ( first { $_ eq 'This is a description' } @lines ), 'Description injected' );
+ok( ( first { $_ eq 'INSTALLATION' } @lines ),          'Installation section injected' );
+ok( ( first { $_ eq 'COPYRIGHT AND LICENSE' } @lines ), 'Copyright section injected' );
+
+done_testing;
+


### PR DESCRIPTION
/cc @ap 

The name probably needs to change, but proof works.
